### PR TITLE
remove vsn nums on shelf. unzip eou on shelf. anon.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Strick Yak
+Copyright (c) 2023 Henry Strickland (Strick Yak) and nitros9project authors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@ Note that the "MIT License" in the file `LICENSE` refers to the
 `coco-shelf` repository.  Other packages expanded here have different
 licenses, including some code under the GNU General Public License.
 
-## Quick Start
+# Quick Start
+
+Here are instructions for building on three platforms:
+   * Ubuntu Linux on 64-bit Intel or AMD
+   * Modern MacOS
+   * Raspian OS on a 64-bit Raspberry Pi
+
+## For Ubuntu Linux on 64-bit Intel or AMD
 Use a modern Linux distro on an x86_64 platform.
 Clone this coco-shelf repo, cd into it, and
 just type `make`.  Let me know what goes wrong!
@@ -22,11 +29,11 @@ within an hour) this works for me:
 export DEBIAN_FRONTEND=noninteractive
 apt -y update < /dev/null
 apt -y upgrade < /dev/null
-apt -y install gcc gcc-doc make flex bison gdb build-essential
-apt -y install git git-doc golang golang-doc zip
+apt -y install gcc gcc make flex bison gdb build-essential
+apt -y install git git golang golang zip
 apt -y install libgmp-dev libmpfr-dev libmpc-dev
 
-# ---- Create a user account 'coco' for builds ----
+# ---- Create a user account 'coco' for doing the build ----
 useradd --shell /bin/bash -m coco
 su - coco
 
@@ -35,6 +42,10 @@ git clone https://github.com/strickyak/coco-shelf.git
 cd coco-shelf/
 make
 ```
+
+(If you don't have an account on github and that ssh key in your
+ssh-agent, change the final `make` to `make-anon` and it will
+clone github repos anonymously, instead of using your account.)
 
 If that succeeded, the last two lines printed will be
 ```
@@ -45,14 +56,28 @@ date > done-frobio
 Above that it lists the products of the frobio build,
 which are in the `build-frobio` directory.
 
+## For MacOS
+
+MacOS can't build the old version of GCC, which is currently
+only needed for building the Axiom bootrom in Frobio.
+
+If you can live without that (most of you can),
+instead of the final "make", use "make all-without-gccretro".
+
+TODO: Are there any other dependencies or packages to load
+for MacOS?  What versions of MacOS does it work on?
+Intel CPU or Apple Silicon?
+
 ## For Raspberry Pi
 
-If you install the packages listed above for Ubuntu,
-everything builds and works on a Raspberry Pi using
+Everything builds and works on a Raspberry Pi using
 this 64 Bit Lite edition
 `2023-05-03-raspios-bullseye-arm64-lite.img.xz`
 except don't install the default version of golang.
 Theirs is version 1.15 and we need at least 1.18.
+
+Install the same packages listed above for Ubuntu,
+except for golang.
 
 Download the latest "arm64" version from https://go.dev/dl/
 and untar it in your home.  Notice there will be a
@@ -72,41 +97,16 @@ chmod +x bin/go
 make
 ```
 
-## Using your own github account
-
-If you have a github account, you can clone the github
-repos under your own username, by editing `conf.mk`
-before typing your first `make`, changing these three lines:
-```
-COCO_TOOLSHED_REPO:=https://github.com/n6il/toolshed
-COCO_NITROS9_REPO:=https://github.com/n6il/nitros9
-COCO_FROBIO_REPO:=https://github.com/strickyak/frobio
-```
-to be like this:
-```
-COCO_TOOLSHED_REPO:=git@github.com:n6il/toolshed.git
-COCO_NITROS9_REPO:=git@github.com:n6il/nitros9.git
-COCO_FROBIO_REPO:=git@github.com:strickyak/frobio.git
-```
-You can also change your clone later by editing the
-`.git/config` and changing the `url =` line.
-
-And if you have your own copy of the repo in github
-to push to, change the usernames `n6il` or `strickyak`
-to your own github username.
-
 ## What is the mirror/ directory?
 
-Because you might not be connected to the internet while
-working on your CoCo (I often am not), everything you
-need from the internet is fetched on your first `make`
-and cached in the `mirror/` directory.  As of this writing,
-that includes 3 tarballs and 3 github repositories.
+Because you might not be connected to the internet while working on
+your CoCo (I often am not), everything you need from the internet is
+fetched on your first `make` and cached in the `mirror/` directory.
+That includes several tarballs and zips and several github repositories.
 
-If you start a new coco-shelf, you can copy (recursively)
-the mirror directory into the new coco-shelf, or symlink it.
-That will save time and bandwidth doing downloads, and will
-work if you are not on the internet.
+If you start a new coco-shelf, you can copy (recursively) the mirror
+directory into the new coco-shelf, or symlink it.  That will save time and
+bandwidth doing downloads, and will work if you are not on the internet.
 
 ## Re-building portions.
 
@@ -114,16 +114,24 @@ If you delete one of the `done-*` files
 ( `done-cmoc done-frobio done-gccretro done-lwtools done-nitros9 done-toolshed` )
 and type `make`, it will rebuild that portion of the shelf.
 
-If you delete the source directory associated with one of those
-portions and type `make`, it will make a new copy of that
-directory from the mirror, and rebuild the portion.
+If you delete the source directory associated with one of those portions
+and type `make`, it will make a new copy of that directory from the
+mirror, and rebuild the portion.
 
 ## Freshening the mirrored portions.
 
-If you want to freshen the git repos in the mirror,
-you can chdir into the mirror directory and type `make pull`.
-That will do a `git pull` in each repo.
+If you want to freshen the git repos in the mirror, you can chdir into
+the mirror directory and type `make pull`.  That will do a `git pull`
+in each repo.
 
-If you want to use a new version of one of the tarballed
-portions, change the version number in `conf.mk` and type
-`make`.  It should fetch it.
+If you want to use a new version of one of the tarballed portions, change
+the version number in `conf.mk` and type `make`.  It should fetch it.
+
+## Final Advice on filenames.
+
+Please don't use spaces or shell meta-characters (like parentheses)
+in your directory path above `coco-shelf` or in file or directory names
+below it.  Shell scripts and Makefiles are simpler and more readable if we
+don't need quote marks and other mitigations against weird characters.
+Dots and dashes and underscores should be just fine, except at the front
+of a name.  Letters and numbers are always good.  No non-ASCII unicode!

--- a/conf.mk
+++ b/conf.mk
@@ -16,12 +16,18 @@ export COCO_CMOC_TARBALL=$(COCO_CMOC_VERSION).tar.gz
 export COCO_GCCRETRO_TARBALL=$(COCO_GCCRETRO_VERSION).tar.bz2
 
 # If you want to clone these from github with your own git ssh key,
-# change "https://github.com/" to
-#        "git@github.com:"
-# on each of these 3 REPO lines, and add ".git" to the end of each.
-COCO_TOOLSHED_REPO:=https://github.com/n6il/toolshed
-COCO_NITROS9_REPO:=https://github.com/n6il/nitros9
-COCO_FROBIO_REPO:=https://github.com/strickyak/frobio
+# change REPO_PREFIX to "git@github.com:" and REPO_SUFFIX to ".git".
+# Or use the "make all-mine" target, which does this for you.
+
+# If you want to clone these from github anonymously
+# (say, if you don't have a github account and the key in your ssh agent),
+# change REPO_PREFIX to "https://" and REPO_SUFFIX to "".
+# Or use the "make all-anon" target, which does this for you.
+REPO_PREFIX=git@github.com:
+REPO_SUFFIX=.git
+COCO_TOOLSHED_REPO:=$(REPO_PREFIX)nitros9project/toolshed$(REPO_SUFFIX)
+COCO_NITROS9_REPO:=$(REPO_PREFIX)nitros9project/nitros9$(REPO_SUFFIX)
+COCO_FROBIO_REPO:=$(REPO_PREFIX)strickyak/frobio$(REPO_SUFFIX)
 
 COCO_LWTOOLS_URL:="http://www.lwtools.ca/releases/lwtools/$(COCO_LWTOOLS_TARBALL)"
 COCO_CMOC_URL:="http://perso.b2b2c.ca/~sarrazip/dev/$(COCO_CMOC_TARBALL)"
@@ -29,5 +35,3 @@ COCO_GCCRETRO_URL:="https://ftp.gnu.org/gnu/gcc/$(COCO_GCCRETRO_VERSION)/$(COCO_
 
 EOU_H6309_URL:=http://www.lcurtisboyle.com/nitros9/EOU_Version%201_0_0_(6309_ONLY)_12-02-2022.zip
 EOU_M6809_URL:=http://www.lcurtisboyle.com/nitros9/EOU_Version%201_0_0_(6809_ONLY)_12-02-2022.zip
-EOU_H6309_ZIP:="EOU_Version%201_0_0_(6309_ONLY)_12-02-2022.zip"
-EOU_M6809_ZIP:="EOU_Version%201_0_0_(6809_ONLY)_12-02-2022.zip"

--- a/mirror/Makefile
+++ b/mirror/Makefile
@@ -17,19 +17,23 @@
 
 include ../conf.mk
 
-all: config.guess $(COCO_LWTOOLS_TARBALL) $(COCO_CMOC_TARBALL) $(COCO_GCCRETRO_TARBALL) toolshed nitros9 frobio eou-all
+all: gcc-config-guess $(COCO_LWTOOLS_TARBALL) $(COCO_CMOC_TARBALL) $(COCO_GCCRETRO_TARBALL) toolshed nitros9 frobio eou-all
 
-# The config.guess shipped in the old retro gcc is too old to know
+# all-anon is an alternataive to "all" that uses your git ssh key.
+all-anon:
+	make all REPO_PREFIX="https://" REPO_SUFFIX=""
+
+# The gcc-config-guess shipped in the old retro gcc is too old to know
 # about Raspberry Pis.  So we need a newer one to replace it.
-config.guess:
-	curl 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' > config.guess
+gcc-config-guess:
+	curl 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' > gcc-config-guess
 
 $(COCO_LWTOOLS_TARBALL):
-	set -x; test -s $@ || curl -O $(COCO_LWTOOLS_URL)
+	set -x; test -s $@ || curl $(COCO_LWTOOLS_URL) > $@
 $(COCO_CMOC_TARBALL):
-	set -x; test -s $@ || curl -O $(COCO_CMOC_URL)
+	set -x; test -s $@ || curl $(COCO_CMOC_URL) > $@
 $(COCO_GCCRETRO_TARBALL):
-	set -x; test -s $@ || curl -O $(COCO_GCCRETRO_URL)
+	set -x; test -s $@ || curl $(COCO_GCCRETRO_URL) > $@
 toolshed:
 	set -x; test -s $@ || git clone $(COCO_TOOLSHED_REPO)
 nitros9:
@@ -37,21 +41,12 @@ nitros9:
 frobio:
 	set -x; test -s $@ || git clone $(COCO_FROBIO_REPO)
 
-eou-all: eou-h6309 eou-m6809
+eou-all: eou-h6309.zip eou-m6809.zip
 
-EOU-1.0.0-h6309.zip:
-	set -x; test -s $@ || { curl -O "$(EOU_H6309_URL)" && mv -v $(EOU_H6309_ZIP) $@ ;}
-EOU-1.0.0-m6809.zip:
-	set -x; test -s $@ || { curl -O "$(EOU_M6809_URL)" && mv -v $(EOU_M6809_ZIP) $@ ;}
-
-eou-h6309: EOU-1.0.0-h6309.zip
-	rm -rf $@
-	mkdir -p $@
-	cd $@ && unzip ../$<
-eou-m6809: EOU-1.0.0-m6809.zip
-	rm -rf $@
-	mkdir -p $@
-	cd $@ && unzip ../$<
+eou-h6309.zip:
+	set -x; test -s $@ || curl "$(EOU_H6309_URL)" > $@
+eou-m6809.zip:
+	set -x; test -s $@ || curl "$(EOU_M6809_URL)" > $@
 
 pull:
 	cd toolshed && git pull
@@ -59,6 +54,7 @@ pull:
 	cd frobio && git pull
 
 clean-mirror:
+	rm -f eou-*
 	rm -f cmoc-*
 	rm -f gcc-*
 	rm -f lwtools-*


### PR DESCRIPTION
This does a number of things for your coco-shelf.

It removes the version numbers from directories on the shelf.  That helps us
write Makefiles and scripts that can borrow files from peer directories. 

It changes the origin of nitros9 and toolshed to github.com/nitros9project (from n6il).
It gets rid of parentheses in filenames for the download of EOU. 

It doesn't expand EOU in the mirror, but on the shelf, like other tarballs.

It renames the mirror download of config.guess to gnu-config-guess
so it doesn't look like part of the mirror's config.

Finally, this new one assumes you have a github account and the github key
is in your ssh-agent.    If you don't want to clone using your account, 
type "make all-anon" instead of "make all", and you get the old behaviour.
