### PR TITLE
fix: prevent whitespace before a # comment being included in the vari…

### DIFF
--- a/conf.mk
+++ b/conf.mk
@@ -5,8 +5,10 @@
 S:=$(shell pwd)
 P:=$(shell echo $$PATH)
 export SHELF:=$S
-export SHELL:=/bin/bash   # Putting this 1st seems to make PATH work.
-export PATH:=$S/bin:$P    # Add coco-shelf/bin at front of PATH.
+# Putting this 1st seems to make PATH work.
+export SHELL:=/bin/bash
+# Add coco-shelf/bin at front of PATH.
+export PATH:=$S/bin:$P
 
 PIZGA_MIRROR_URL:=http://pizga.net/inputs
 


### PR DESCRIPTION
…able value

This was a tricky one that bit me when using Fedora Linux. In GNU Make, when using the := assignment, any whitespace before a # comment is included in the variable's value. This resulted in PATH ending with several spaces (e.g., /usr/bin    ). When the shell (bash) tried to find the rm command, it looked in the directory /usr/bin (with trailing spaces), which does not exist, leading to the command not found error.